### PR TITLE
openmp v20.1.8

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,9 @@
-staging_channel_upload_target: llvm-19.1.7-stage1-build-2
+build_parameters:
+  - "--suppress-variables"
+  - "--error-overlinking"
+
+staging_channel_upload_target: llvm-20.1.8-stage0-build-0
 
 channels:
   - https://staging.continuum.io/prefect/llvm-19.1.7-stage1-build-2
+  - https://staging.continuum.io/prefect/llvm-20.1.8-stage0-build-0

--- a/abs.yaml
+++ b/abs.yaml
@@ -5,4 +5,4 @@ build_parameters:
 staging_channel_upload_target: llvm-20.1.8-stage2-build-0
 
 channels:
-  - https://staging.continuum.io/prefect/llvm-20.1.8-stage1-build-0
+  - https://staging.continuum.io/prefect/llvm-20.1.8-stage2-build-0

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,8 +1,4 @@
 build_parameters:
   - "--suppress-variables"
   - "--error-overlinking"
-
-staging_channel_upload_target: llvm-20.1.8-stage2-build-0
-
-channels:
-  - https://staging.continuum.io/prefect/llvm-20.1.8-stage2-build-0
+  - "-c https://staging.continuum.io/prefect/llvm-20.1.8-stage2-build-0"

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,8 @@
-staging_channel_upload_target: llvm-20.1.8-stage0-build-0
+build_parameters:
+  - "--suppress-variables"
+  - "--error-overlinking"
+
+staging_channel_upload_target: llvm-20.1.8-stage2-build-0
 
 channels:
-  - https://staging.continuum.io/prefect/llvm-20.1.8-stage0-build-0
+  - https://staging.continuum.io/prefect/llvm-20.1.8-stage1-build-0

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,7 +1,3 @@
-build_parameters:
-  - "--suppress-variables"
-  - "--error-overlinking"
-
 staging_channel_upload_target: llvm-20.1.8-stage0-build-0
 
 channels:

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,3 +1,8 @@
+fortran_compiler:          # [win]
+  - flang                  # [win]
+fortran_compiler_version:  # [win]
+  - 20.1.8                 # [win]
+
 c_compiler:          # [osx]
   - clang_bootstrap  # [osx]
 cxx_compiler:        # [osx]    

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "19.1.7" %}
+{% set version = "20.1.8" %}
 # check https://clang.llvm.org/docs/OpenMPSupport.html
 # occasionally to see last fully supported openmp ver.
 {% set openmp_ver = "4.5" %}
@@ -15,7 +15,7 @@ package:
 
 source:
   url: https://github.com/llvm/llvm-project/archive/refs/tags/llvmorg-{{ version.replace(".rc", "-rc") }}.tar.gz
-  sha256: 59abea1c22e64933fad4de1671a61cdb934098793c7a31b333ff58dc41bff36c
+  sha256: a6cbad9b2243b17e87795817cfff2107d113543a12486586f8a055a2bb044963
   # name folder for easier deletion; we do the equivalent of downloading
   # the subproject sources, so the work folder then has openmp in it;
   # for details see build scripts
@@ -26,7 +26,7 @@ source:
     - patches/0002-win-fix-link-flags.patch  # [win]
 
 build:
-  number: 2
+  number: 0
 
 requirements:
   build:


### PR DESCRIPTION
openmp v20.1.8

## Links
- [PKG-8678](https://anaconda.atlassian.net/browse/PKG-8678)
- [Artifacts](https://staging.continuum.io/prefect/llvm-20.1.8-stage2-build-0)

## Changes
- Bump version and SHA, reset build number
- Build with llvm 20
- Use our new flang compiler on windows. 

## Notes
- Linter errors appear to be false negatives.

## Related PRs
- ✅ https://github.com/AnacondaRecipes/cctools-and-ld64-feedstock/pull/17
- ✅  https://github.com/AnacondaRecipes/clang-compiler-activation-feedstock/pull/23
- https://github.com/AnacondaRecipes/libcxx-feedstock/pull/15
- https://github.com/AnacondaRecipes/llvmdev-feedstock/pull/29
- https://github.com/AnacondaRecipes/clangdev-feedstock/pull/16
- https://github.com/AnacondaRecipes/compiler-rt-feedstock/pull/9
-  ✅ https://github.com/AnacondaRecipes/mlir-feedstock/pull/8
-  ✅ https://github.com/AnacondaRecipes/lld-feedstock/pull/12
- https://github.com/AnacondaRecipes/openmp-feedstock/pull/6
- https://github.com/AnacondaRecipes/clang-win-activation-feedstock/pull/6
- https://github.com/AnacondaRecipes/flang-feedstock/pull/2
- https://github.com/AnacondaRecipes/flang-activation-feedstock/pull/1


[PKG-8678]: https://anaconda.atlassian.net/browse/PKG-8678?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ