### PR TITLE
Use openmp mutex for all.

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -2,8 +2,7 @@ build_parameters:
   - "--suppress-variables"
   - "--error-overlinking"
 
-staging_channel_upload_target: openmp-mutex-rework-3
+staging_channel_upload_target: openmp-mutex-rework-4
 
 channels:
-  - https://staging.continuum.io/pbp/fs/_openmp_mutex-feedstock/pr2/6bb2abb
-  - https://staging.continuum.io/pbp/openmp-mutex-rework-3
+  - https://staging.continuum.io/pbp/openmp-mutex-rework-4

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,8 +1,3 @@
 build_parameters:
   - "--suppress-variables"
   - "--error-overlinking"
-
-staging_channel_upload_target: openmp-mutex-rework-4
-
-channels:
-  - https://staging.continuum.io/pbp/openmp-mutex-rework-4

--- a/abs.yaml
+++ b/abs.yaml
@@ -2,7 +2,8 @@ build_parameters:
   - "--suppress-variables"
   - "--error-overlinking"
 
-staging_channel_upload_target: openmp-mutex-rework-2
+staging_channel_upload_target: openmp-mutex-rework-3
 
 channels:
   - https://staging.continuum.io/pbp/fs/_openmp_mutex-feedstock/pr2/6bb2abb
+  - https://staging.continuum.io/pbp/openmp-mutex-rework-3

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,6 @@
 build_parameters:
   - "--suppress-variables"
   - "--error-overlinking"
+
+channels:
+  - build

--- a/abs.yaml
+++ b/abs.yaml
@@ -2,5 +2,7 @@ build_parameters:
   - "--suppress-variables"
   - "--error-overlinking"
 
+staging_channel_upload_target: openmp-mutex-rework-2
+
 channels:
-  - build
+  - https://staging.continuum.io/pbp/fs/_openmp_mutex-feedstock/pr2/6bb2abb

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -71,7 +71,7 @@ outputs:
       run_exports:
         strong:
           - {{ pin_subpackage("llvm-openmp", max_pin=None) }}
-          - _openmp_mutex >=6.0 *_llvm
+          - _openmp_mutex *_llvm
     requirements:
       build:
         # cmake depends on llvm-openmp on macOS (circular dep); use ninja instead
@@ -137,7 +137,7 @@ outputs:
       run_exports:
         strong:
           - {{ pin_subpackage("llvm-openmp", max_pin=None) }}
-          - _openmp_mutex >=6.0 *_llvm
+          - _openmp_mutex *_llvm
     requirements:
       build:
         - cmake

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,4 @@
 {% set version = "22.1.2" %}
-# check https://clang.llvm.org/docs/OpenMPSupport.html
-# occasionally to see last fully supported openmp ver.
-{% set openmp_ver = "4.5" %}
 
 # on osx we need to use cxx_compiler_version, rest can use package version
 {% set clang_major = version.split(".")[0]|int %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,7 +29,7 @@ source:
     - patches/0003-fix-module-set-property-runtime-src.patch  # [win]
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
@@ -71,8 +71,7 @@ outputs:
       run_exports:
         strong:
           - {{ pin_subpackage("llvm-openmp", max_pin=None) }}
-          - _openmp_mutex >={{ openmp_ver }}  # [linux]
-          - _openmp_mutex * *_llvm            # [linux]
+          - _openmp_mutex >=6.0 *_llvm
     requirements:
       build:
         # cmake depends on llvm-openmp on macOS (circular dep); use ninja instead
@@ -138,8 +137,7 @@ outputs:
       run_exports:
         strong:
           - {{ pin_subpackage("llvm-openmp", max_pin=None) }}
-          - _openmp_mutex >={{ openmp_ver }}  # [linux]
-          - _openmp_mutex * *_llvm            # [linux]
+          - _openmp_mutex >=6.0 *_llvm
     requirements:
       build:
         - cmake

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -71,7 +71,7 @@ outputs:
       run_exports:
         strong:
           - {{ pin_subpackage("llvm-openmp", max_pin=None) }}
-          - _openmp_mutex *_llvm
+          - _openmp_mutex * *_llvm
     requirements:
       build:
         # cmake depends on llvm-openmp on macOS (circular dep); use ninja instead
@@ -137,7 +137,7 @@ outputs:
       run_exports:
         strong:
           - {{ pin_subpackage("llvm-openmp", max_pin=None) }}
-          - _openmp_mutex *_llvm
+          - _openmp_mutex * *_llvm
     requirements:
       build:
         - cmake


### PR DESCRIPTION
llvm-openmp rebuild

**Destination channel:** defaults

### Links

- [PKG-14393](https://anaconda.atlassian.net/browse/PKG-14393) 

- Relevant dependency PRs:
  - https://github.com/AnacondaRecipes/_openmp_mutex-feedstock/pull/2

### Explanation of changes:

- Add `_openmp_mutex *_llvm` as a strong run export for `llvm-openmp`.
- Add the same mutex run export for `llvm-openmp-fortran`, which exports `llvm-openmp`.
- Replace the older Linux-only mutex constraints with a single cross-platform `_llvm` mutex requirement.
- Bump the build number so the updated metadata is published.


[PKG-14393]: https://anaconda.atlassian.net/browse/PKG-14393?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ